### PR TITLE
fixed the white space error with out reordering the parameters

### DIFF
--- a/db.sh
+++ b/db.sh
@@ -25,19 +25,19 @@ SHDBDIR=$(pwd)
 #obsolete case switch used just for Sandra C. Look how human readable it is.
 case $1 in
   add) 	
-    /bin/sh $SHDBDIR/dbadd.1.1 $2 $3 $4 && exit 4; 	
+    /bin/sh "$SHDBDIR/dbadd.1.1" "$2" "$3" "$4" && exit 4; 	
     exit 1;
   ;; 
   del) 	
-    /bin/sh $SHDBDIR/dbdel.1.2 $2 $3 && exit 0;
+    /bin/sh "$SHDBDIR/dbdel.1.2" "$2" "$3" && exit 0;
     exit 1;
   ;;
   rep)
-    /bin/sh $SHDBDIR/dbrep.1.3 $2 $3 $4 && exit 0;
+    /bin/sh "$SHDBDIR/dbrep.1.3" "$2" "$3" "$4" && exit 0;
     exit 1;
   ;; 
   get)
-    /bin/sh $SHDBDIR/dbget.1.4 $2 $3 && exit 0;
+    /bin/sh "$SHDBDIR/dbget.1.4" "$2" "$3" && exit 0;
     exit 1;
   ;;
   *)

--- a/dbadd.1.1
+++ b/dbadd.1.1
@@ -27,24 +27,24 @@
 # finally if all conditions are met writes the new pair to file and exits with 0
 # will return error message on fail and exit with 1
 
-if [ -z $1 ] || [ -z $2 ] || [ -z $3 ]
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]
  then
 	echo "Syntax: dbadd <key> <value> <db file>";
 	exit 1;
- elif [ ! -f $3 ]
+ elif [ ! -f "$3" ]
  then
 	echo "Error: database file not found";
 	exit 1;
- elif [ ! -w $3 ] || [ ! -r $3 ]
+ elif [ ! -w "$3" ] || [ ! -r "$3" ]
  then
 	echo "Error: can not read or write to database file";
 	exit 1;
 
- elif [ ! -z $(db get $1 $3) ]
+ elif [ ! -z "$(db get "$1" "$3")" ]
  then
 	echo "Error: Key exists";
 	exit 1;
  else
-echo "$1	$2" | cat >> $3 -;
+echo "$1	$2" | cat >> "$3" -;
 	exit 0;
 fi;

--- a/dbdel.1.2
+++ b/dbdel.1.2
@@ -27,25 +27,25 @@
  #the row being deleted and over writes with any results.
 # exits 1 on error and 0 on success
 # 
-if [ -z $1 ] || [ -z $2 ]
+if [ -z "$1" ] || [ -z "$2" ]
  then
 	echo "Syntax: dbdel <key> <file>";
 	exit 1;	
- elif [ ! -f $2 ]
+ elif [ ! -f "$2" ]
  then
 	echo "Error: database file not found";
 	exit 1;
- elif [ ! -r $2 ] || [ ! -w $2 ]
+ elif [ ! -r "$2" ] || [ ! -w "$2" ]
  then
 	echo "Error: can not read or write database file";
 	exit 1;
  else
-	NEWFILE=$(grep -v "^$1	" $2);
+	NEWFILE=$(grep -v "^$1	" "$2");
 	if [ ! -z "$NEWFILE" ]
 	 then
-		echo "$NEWFILE" | cat > $2 -;
+		echo "$NEWFILE" | cat > "$2" -;
 	 else
-		echo -n "" | cat > $2 -;
+		echo -n "" | cat > "$2" -;
 	fi;
 	exit 0;
 fi;

--- a/dbget.1.4
+++ b/dbget.1.4
@@ -26,15 +26,15 @@
 # returns associated value for key when found
 # exit on 1 on error.
 
-if [ -z $1 ] || [ -z $2 ]
+if [ -z "$1" ] || [ -z "$2" ]
  then 
 	echo "Error: dbget <key> <file>"
 	exit 1;
- elif [ ! -f $2 ]
+ elif [ ! -f "$2" ]
  then
 	echo "Error: database file not found";
 	exit 1; 
- elif [ ! -r $2 ]
+ elif [ ! -r "$2" ]
  then
 	echo "Error: can not read database file";
 	exit 1;
@@ -47,5 +47,5 @@ if [ -z $1 ] || [ -z $2 ]
 			echo $(echo "$f" | cut -d\	 -f2);
 			exit 0;
 		fi;	
-	 done < $2 
+	 done < "$2" 
 fi;

--- a/dbrep.1.3
+++ b/dbrep.1.3
@@ -35,15 +35,15 @@
 #------------------
 # Unique/random temp file name would allow more than one replace case to be run at the same time.
 
-if [ -z $1 ] || [ -z $2 ] || [ -z $3 ]
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]
  then
 	echo "Syntax: dbrep <replace key> <new value> <db file>";
 	exit 1;
- elif [ ! -f $3 ]
+ elif [ ! -f "$3" ]
  then
 	echo "Error: database not found";
 	exit 1;
- elif [ ! -r $3 ] || [ ! -w $3 ]
+ elif [ ! -r "$3" ] || [ ! -w "$3" ]
  then
 	echo "Error: can not read or write from database file: $3";
 	exit 1;
@@ -68,10 +68,10 @@ if [ -z $1 ] || [ -z $2 ] || [ -z $3 ]
 		 else
 			echo "$f" | cat >> ~/dbtemp -;
 		fi;
-	done < $3;
+	done < "$3";
 	if [ "$FOUND" = "TRUE" ]
 	 then 
-		cat ~/dbtemp | cat > $3 -;
+		cat ~/dbtemp | cat > "$3" -;
 		rm ~/dbtemp;
 	 else
 		echo "Error: Key not found";


### PR DESCRIPTION
All the code needed to parse strings was a whole bunch of quotes around $n parameters. #3 solved.
Engine can now parse: keys, values, path+filename, as strings including whitespace (no tab for keys) and escape charaters.
String parameters must be incapsulated in quotes.